### PR TITLE
Dockerfile: Corrected hdf5 tarball path + updated OMPI + Singularity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN apt-get update && \
 
 # Install OpenMPI
 RUN cd /tmp  &&  \
-    wget http://www.open-mpi.org/software/ompi/v1.8/downloads/openmpi-1.8.2.tar.gz && \
-    tar xvfz openmpi-1.8.2.tar.gz && \
-    cd openmpi-1.8.2 && \
-    ./configure --prefix=/usr/local/openmpi && \
+    wget https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.gz && \
+    tar xvfz openmpi-2.1.1.tar.gz && \
+    cd openmpi-2.1.1 && \
+    ./configure CC=gcc CXX=g++ --enable-mpi-cxx --prefix=/usr/local/openmpi && \
     make -j 8 && \
     sudo make install && rm -rf /tmp/*
 
@@ -80,9 +80,9 @@ RUN cd /tmp && \
     cp -rf cub-1.5.2/cub/ /usr/local/include/ && \
     rm -rf /tmp/*
 
-# Ensure OpenMPI is avaiable on path
+# Ensure OpenMPI is available on path
 ENV PATH=/usr/local/openmpi/bin/:${PATH} \
-    LD_LIBRARY_PATH=/usr/local/lib/:${LD_LIBRARY_PATH}
+    LD_LIBRARY_PATH=/usr/local/lib/:/usr/local/openmpi/lib/:${LD_LIBRARY_PATH}
 
 # Build latest version of DSSTNE from source
 COPY . /opt/amazon/dsstne
@@ -91,4 +91,3 @@ RUN cd /opt/amazon/dsstne/src/amazon/dsstne && \
 
 # Add DSSTNE binaries to PATH
 ENV PATH=/opt/amazon/dsstne/src/amazon/dsstne/bin/:${PATH}
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN cd /tmp  &&  \
     tar xvfz openmpi-1.8.2.tar.gz && \
     cd openmpi-1.8.2 && \
     ./configure --prefix=/usr/local/openmpi && \
-    make && \
+    make -j 8 && \
     sudo make install && rm -rf /tmp/*
 
 # Install JSONCPP
@@ -34,16 +34,16 @@ RUN cd /tmp  && \
     mkdir -p build/release && \
     cd build/release && \
     cmake -DCMAKE_BUILD_TYPE=release -DJSONCPP_LIB_BUILD_SHARED=OFF -G "Unix Makefiles" ../.. && \
-    make && \
+    make -j 8 && \
     make install && rm -rf /tmp/*
 
 # Install hdf5
 RUN cd /tmp && \
-    wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8.12/src/hdf5-1.8.12.tar.gz && \
+    wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.12/src/hdf5-1.8.12.tar.gz && \
     tar xvfz hdf5-1.8.12.tar.gz && \
     cd hdf5-1.8.12 && \
     ./configure --prefix=/usr/local && \
-    make && \
+    make -j 8 && \
     make install && rm -rf /tmp/*
 
 # Install zlib
@@ -52,7 +52,7 @@ RUN cd /tmp && \
     tar xvf zlib-1.2.8.tar.gz && \
     cd zlib-1.2.8 && \
     ./configure && \
-    make && \
+    make -j 8 && \
     make install && rm -rf /tmp/*
 
 # Install netcdf
@@ -61,7 +61,7 @@ RUN cd /tmp && \
     tar xvf netcdf-4.1.3.tar.gz && \
     cd netcdf-4.1.3 && \
     ./configure --prefix=/usr/local && \
-    make && \
+    make -j 8 && \
     make install && rm -rf /tmp/*
 
 # Install netcdf-cxx
@@ -70,7 +70,7 @@ RUN cd /tmp && \
     tar xvf netcdf-cxx4-4.2.tar.gz && \
     cd netcdf-cxx4-4.2 && \
     ./configure --prefix=/usr/local && \
-    make && \
+    make -j 8 && \
     make install && rm -rf /tmp/*
 
 # Installing CUBG

--- a/Singularity
+++ b/Singularity
@@ -1,0 +1,85 @@
+Bootstrap: docker
+From: nvidia/cuda:7.5-cudnn5-devel-ubuntu14.04
+
+%environment
+    DEBIAN_FRONTEND=noninteractive
+    LD_LIBRARY_PATH=/usr/local/lib/:/usr/local/openmpi/lib/
+    PATH=/amazon-dsstne/src/amazon/dsstne/bin/:/usr/local/openmpi/bin/:${PATH}
+    export DEBIAN_FRONTEND LD_LIBRARY_PATH PATH
+
+%setup
+    echo $SINGULARITY_ROOTFS
+    echo "cp -r . $SINGULARITY_ROOTFS/"
+    cp Singularity $SINGULARITY_ROOTFS/
+    cp -r ./amazon-dsstne/ $SINGULARITY_ROOTFS/
+
+%post
+    apt-get update && \
+    apt-get install -y build-essential libcppunit-dev libatlas-base-dev pkg-config python \
+        software-properties-common unzip wget && \
+    add-apt-repository ppa:george-edison55/cmake-3.x && \
+    apt-get update && \
+    apt-get install -y cmake && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+    cd /tmp  &&  \
+    wget https://www.open-mpi.org/software/ompi/v2.1/downloads/openmpi-2.1.1.tar.gz && \
+    tar xvfz openmpi-2.1.1.tar.gz && \
+    cd openmpi-2.1.1 && \
+    ./configure CC=gcc CXX=g++ --enable-mpi-cxx --prefix=/usr/local/openmpi && \
+    make -j 8 && \
+    sudo make install && rm -rf /tmp/*
+
+    cd /tmp  && \
+    wget https://github.com/open-source-parsers/jsoncpp/archive/svn-import.tar.gz && \
+    tar xvfz svn-import.tar.gz && \
+    cd jsoncpp-svn-import && \
+    mkdir -p build/release && \
+    cd build/release && \
+    cmake -DCMAKE_BUILD_TYPE=release -DJSONCPP_LIB_BUILD_SHARED=OFF -G "Unix Makefiles" ../.. && \
+    make -j 8 && \
+    make install && rm -rf /tmp/*
+
+    cd /tmp && \
+    wget ftp://ftp.unidata.ucar.edu/pub/netcdf/netcdf-4/hdf5-1.8.9.tar.gz && \
+    tar xvfz hdf5-1.8.9.tar.gz && \
+    cd hdf5-1.8.9 && \
+    ./configure --prefix=/usr/local &&\
+    make -j 8 && \
+    make install && rm -rf /tmp/*
+
+    cd /tmp && \
+    wget https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4/zlib-1.2.8.tar.gz && \
+    tar xvf zlib-1.2.8.tar.gz && \
+    cd zlib-1.2.8 && \
+    ./configure && \
+    make -j 8 && \
+    make install && rm -rf /tmp/*
+
+    cd /tmp && \
+    wget https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-4.1.3.tar.gz && \
+    tar xvf netcdf-4.1.3.tar.gz && \
+    cd netcdf-4.1.3 && \
+    ./configure --prefix=/usr/local && \
+    make -j 8 && \
+    make install && rm -rf /tmp/*
+
+    cd /tmp && \
+    wget https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-cxx4-4.2.tar.gz && \
+    tar xvf netcdf-cxx4-4.2.tar.gz && \
+    cd netcdf-cxx4-4.2 && \
+    ./configure --prefix=/usr/local && \
+    make -j 8 && \
+    make install && rm -rf /tmp/*
+
+    cd /tmp && \
+    wget https://github.com/NVlabs/cub/archive/1.5.2.zip && \
+    unzip 1.5.2.zip && \
+    cp -rf cub-1.5.2/cub/ /usr/local/include/ && \
+    rm -rf /tmp/*
+
+    export LD_LIBRARY_PATH=/usr/local/lib/:/usr/local/openmpi/lib/:${LD_LIBRARY_PATH}
+    export PATH=/amazon-dsstne/src/amazon/dsstne/bin:/usr/local/openmpi/bin:/usr/local/bin:/usr/local/include/bin:/usr/local/cuda-7.5/bin:${PATH}
+    cd /amazon-dsstne/src/amazon/dsstne && \
+    make install

--- a/src/amazon/dsstne/Makefile.inc
+++ b/src/amazon/dsstne/Makefile.inc
@@ -18,7 +18,7 @@ endif
 NVCC = nvcc
 CU_FLAGS = -use_fast_math --ptxas-options="-v" -gencode arch=compute_50,code=sm_50 -gencode arch=compute_30,code=sm_30 -DOMPI_SKIP_MPICXX -std=c++11
 CU_INCLUDES = -I/usr/local/cuda/include -IB40C -IB40C/KernelCommon -I/usr/local/include -I/usr/local/openmpi/include -I/usr/include/jsoncpp -I../utils -I../engine -I/usr/include/cppunit
-CU_LIBS = -L/usr/lib/atlas-base -L/usr/local/cuda/lib64 -L. -L/usr/local/lib/
+CU_LIBS = -L/usr/lib/atlas-base -L/usr/local/cuda/lib64 -L. -L/usr/local/lib/ -L/usr/local/openmpi/lib/
 CU_LOADLIBS = -lcudnn -lcurand -lcublas -lcudart -lmpi -lmpi_cxx -ljsoncpp -lnetcdf_c++4 -lnetcdf -l:libcblas.a -l:libatlas.a -ldl -lstdc++  
 
 LOAD = mpiCC


### PR DESCRIPTION
As the summary say, Docker build is failing and is slow.
Changed to working hdf5 tarball path and added parallel
build flag. Singularity container support is added in
OMPI 2.1.x hence bouncing the usage version in dsstne.
Tested locally on docker build.

Signed-off-by: Mohan Gandhi <mohgan@amazon.com>