### PR TITLE
fix for issue #69 - allowing values for features

### DIFF
--- a/src/amazon/dsstne/utils/Filters.cpp
+++ b/src/amazon/dsstne/utils/Filters.cpp
@@ -117,12 +117,6 @@ void SamplesFilter::loadSingleFilter(unordered_map<string, unsigned int> &xMInpu
                         if (vals.size() > 1)
                         {
                             value = atof(vals[1].c_str());
-                            // This is hack for reading just the recs
-                            // Because the current one has date
-                            if (value > 10.0)
-                            {
-                                value = 0.0f;
-                            }
                         }
                         (*sampleFilter)[key] = value;
                     }


### PR DESCRIPTION
*Issue #, if available:*
#69 

*Description of changes:*
Removed the lines of code labeled Hack, that check for values greater than 10 then assign it a zero.
Verified that the parsing to .nc files writes out a data section when the analog flag is set.
Verified that MovieLen still works correctly (which doesn't use analog, to verify that this didn't impact non-analog case).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
