### PR TITLE
Fixes to markdown headers for benchmark docs

### DIFF
--- a/benchmarks/Benchmark.md
+++ b/benchmarks/Benchmark.md
@@ -1,4 +1,4 @@
-#Benchmarks for DSSTNE
+# Benchmarks for DSSTNE
 We ran the benchmark of DSSTNE using the Movielens data set. Training Parameter Specific
 * 27278 input/output dimensions
 * 3 Hidden Sigmoid layers with 1024 each
@@ -8,13 +8,13 @@ We ran the benchmark of DSSTNE using the Movielens data set. Training Parameter 
 Time taken to run one epoch is considered for performance comparison
 
 
-#DSSTNE
-Use the Config at [config.json](dsstne/config.json). Follow the [example](../docs/getting_started/examples.md) and change the traning command
+## DSSTNE
+Use the Config at [config.json](dsstne/config.json). Follow the [example](../docs/getting_started/examples.md) and change the training command
 ```bash
 train -i gl_input.nc -o gl_output.nc -d gl -c config.json -b 256 -e 20 -n gl_network.nc
 ```
 
-#TensorFlow
+## TensorFlow
 [autoencoder.py](tf/autoencoder.py) -u 1024 -b 256 -i 1082 -v54 --vocab_size 27278 -l 3 -f /input/data/ml20m-all.remotcc
 
 

--- a/benchmarks/Benchmark.md
+++ b/benchmarks/Benchmark.md
@@ -15,6 +15,8 @@ train -i gl_input.nc -o gl_output.nc -d gl -c config.json -b 256 -e 20 -n gl_net
 ```
 
 ## TensorFlow
-[autoencoder.py](tf/autoencoder.py) -u 1024 -b 256 -i 1082 -v54 --vocab_size 27278 -l 3 -f /input/data/ml20m-all.remotcc
-
+[autoencoder.py](tf/autoencoder.py) 
+```bash
+autoencoder.py -u 1024 -b 256 -i 1082 -v54 --vocab_size 27278 -l 3 -f /input/data/ml20m-all.remotcc
+```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes to markdown headers for benchmark docs. The old headers did not have a space and did not render correctly. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
