### PR TITLE
adding CDL support to encoder

### DIFF
--- a/docs/getting_started/CDL.txt
+++ b/docs/getting_started/CDL.txt
@@ -1,32 +1,33 @@
 Command Definition Language (Rev 0.1):
 
-{
-    "Network" : <String>                    # NetCDF, JSON Object, or service object containing network
-    "Command" : <String>                    # Command to execute "Train", "Predict"
+TrainingParameters - only used if Command is Train
+PredictionParameters - only used if Command is Predict
+
+
+    "Network" : <String>                    # NetCDF or JSON file path (default "config.json")
+    "Command" : <String>                    # (required) Command to execute "Train", "Predict", or "Validate"
     "RandomSeed" : <Integer>                # Initializes RNG for reproducible runs (default -1, sets from time of day)
-    "TrainingParameters" : {
-        "Epochs" : <Integer>                # Number of training epochs (Mandatory)
-        "MiniBatch" : <Integer>             # Mini-batch size (default 500, use 0 for entire dataset)
-        "Alpha" : <float>                   # Learning rate (default 0.1)
-        "Lambda" : <float>                  # Regularization/Weight Decay weight (default 0.001)
-        "mu" : <float>                      # Momentum update parameter (default 0.9)
-        "AlphaInterval" : <float>           # Interval between learning rate updates (default 0: constant)
-        "AlphaMultiplier" : <float>         # Amount by which to multiply learning rate per above interval (default: 0.5)
-        "Optimizer" : <String>              # Optimization method, either "SGD", "Momentum", "RMSPROP", or "Nesterov" (default "SGD")
-        "CheckPoint" : {
-            "Name" : <String>               # Location to write checkpoint information
-            "Interval" : <Integer>          # Number of minutes between writing checkpoint data (default 30)
-        },
-        "ShuffleIndices" : <Boolean>        # Shuffle training examples once per epoch? (default false)
-    },
-    "PredictionParameters" : {
-        "MiniBatch" : <Integer>             # Mini-batch size (default 500, use 0 for entire dataset)
-    },
-    "Data" : [                              # List of data sources
+    "Data" : [                              # (required) List of data source files
         <String>
         .
         .
         .
     ],
-    "Results" : <String>                    # Location to write results (File or S3 Object)
+    "TrainingParameters" : {
+        "Epochs" : <Integer>                # (required) Number of training epochs
+        "MiniBatch" : <Integer>             # Mini-batch size (default 500, use 0 for entire dataset)
+        "Alpha" : <float>                   # Learning rate (default 0.1)
+        "Lambda" : <float>                  # Regularization/Weight Decay weight (default 0.001)
+        "mu" : <float>                      # Momentum update parameter (default 0.9)
+        "AlphaInterval" : <float>           # Interval between learning rate updates (default 0: constant)
+        "AlphaMultiplier" : <float>         # Learning rate multiplier per Interval (default: 0.5, or if lr is constant: 1.0)
+        "Optimizer" : <String>              # Optimization method, either "SGD", "Momentum", "RMSPROP", or "Nesterov" (default "SGD")
+        "CheckpointName" : <String>         # Location to write checkpoint information, appended with epoch number and ".nc" (default "check")
+        "CheckpointInterval" : <Integer>    # Number of epochs between writing checkpoint data (default 1)
+        "ShuffleIndices" : <Boolean>        # Shuffle training examples once per epoch? (default false)
+        "Results" : <String>                # Location to write results (File or S3 Object) (default "network.nc")
+    },
+    "PredictionParameters" : {
+        "MiniBatch" : <Integer>             # Mini-batch size (default 500, use 0 for entire dataset)
+    },
 }

--- a/samples/cifar-10/dparse.cpp
+++ b/samples/cifar-10/dparse.cpp
@@ -1,11 +1,16 @@
 // Parser to generate training and test data sets for CIFAR-10
 //
-// Step 1. Download CIFAR-10 from https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz
-// Step 2. mv test_batch.bin test.bin
-// Step 3. cat data_batch_*.bin > training.bin
-// Step 4. g++ dparse.cpp -o dparse -lnetcdf -lnetcdf_c++4 --std=c++0x
-// Step 5. ./dparse
-// Step 6. Use the network in config.json with cifar-10-training.nc and cifar-10-test.nc, P@1~=81%
+// Linux steps:
+// wget https://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz
+// tar xvf cifar-10-binary.tar.gz
+// cd cifar-10-batches-bin
+// mv test_batch.bin test.bin
+// cat data_batch_*.bin > training.bin
+// rm data_batch_*
+// g++ dparse.cpp -o dparse -lnetcdf -lnetcdf_c++4 --std=c++0x
+// ./dparse
+// to train (modify train.cdl to suit your needs):  encoder train.cdl
+// to make predictions:  encoder predict.cdl
 
 #include <chrono>
 #include <cstdio>

--- a/samples/cifar-10/predict.cdl
+++ b/samples/cifar-10/predict.cdl
@@ -1,0 +1,8 @@
+{
+    "Version" : 0.2,
+    "Network" : "network.nc",
+    "Command" : "Predict",
+    "RandomSeed" : 12345,
+
+    "Data" : "cifar10_test.nc"
+}

--- a/samples/cifar-10/train.cdl
+++ b/samples/cifar-10/train.cdl
@@ -1,0 +1,18 @@
+{
+    "Version" : 0.2,
+    "Network" : "config.json",
+    "Command" : "Train",
+    "RandomSeed" : 12345,
+
+    "TrainingParameters" : {
+        "Optimizer" : "Nesterov",
+        "Epochs" : 60,
+        "Alpha" : 0.025,
+        "AlphaInterval" : 20,
+        "AlphaMultiplier" : 0.8,
+        "mu": 0.5,
+        "lambda" : 0.0001,
+        "Results" : "network.nc"
+    },
+    "Data" : "cifar10_training.nc"
+}

--- a/src/amazon/dsstne/utils/Makefile
+++ b/src/amazon/dsstne/utils/Makefile
@@ -7,7 +7,7 @@ VPATH=
 
 include ../Makefile.inc
 
-OBJS= Utils.o NetCDFhelper.o NNRecsGenerator.o Filters.o
+OBJS= Utils.o NetCDFhelper.o NNRecsGenerator.o Filters.o cdl.o
 LIB_DSSTNE=../lib/libdsstne.a
 
 COMMON_LIBS = $(LIB_DSSTNE) $(MATH_LIBS) $(MPI_LIBS) $(CU_LIBS) $(CU_LOADLIBS)

--- a/src/amazon/dsstne/utils/cdl.cpp
+++ b/src/amazon/dsstne/utils/cdl.cpp
@@ -1,0 +1,176 @@
+#include "GpuTypes.h"
+#include "NNTypes.h"
+#include "cdl.h"
+
+static std::map<string, TrainingMode> sOptimizationMap = {
+    {"sgd",         TrainingMode::SGD},
+    {"nesterov",    TrainingMode::Nesterov}
+};
+
+
+CDL::CDL()
+{
+    _randomSeed = time(NULL);
+    _alphaInterval = 0;
+    _alphaMultiplier = 0.5f;
+    _batch = 1024;
+    _checkpointInterval = 1;
+    _checkpointFileName = "check";
+    _shuffleIndexes = false;
+    _resultsFileName = "network.nc";
+    _alpha = 0.1f;
+    _lambda = 0.001f;
+    _mu = 0.9f;
+    _optimizer = TrainingMode::SGD;
+}
+
+
+int CDL::Load_JSON(const string& fname)
+{
+    // flags for mandatory values - check to make sure they have been set during load
+    // overall flags
+    bool networkSet=false, commandSet=false, dataSet=false;
+    // flags for when in training mode
+    bool epochsSet=false;
+
+    Json::Reader reader;
+    Json::Value index;
+
+    std::ifstream stream(fname, std::ifstream::binary);
+    bool parsedSuccess = reader.parse(stream, index, false);
+    if (!parsedSuccess)
+    {
+        printf("CDL::Load_JSON: Failed to parse JSON file: %s, error: %s\n", fname.c_str(), reader.getFormattedErrorMessages().c_str());
+        return -1;
+    }
+
+    for (Json::ValueIterator itr = index.begin(); itr != index.end() ; itr++)
+    {
+        // Extract JSON object key/value pair
+        string name                         = itr.name();
+        std::transform(name.begin(), name.end(), name.begin(), ::tolower);
+        Json::Value key                     = itr.key();
+        Json::Value value                   = *itr;
+        string vstring                      = value.isString() ? value.asString() : "";
+        std::transform(vstring.begin(), vstring.end(), vstring.begin(), ::tolower);
+
+        if (name.compare("version") == 0)
+        {
+            float version = value.asFloat();
+            // we only have this first version, but we will have future versions, then we will
+            // need to do something, until then noop
+        }
+        else if (name.compare("network") == 0)
+        {
+            _networkFileName = value.asString();
+            networkSet = true;
+        }
+        else if (name.compare("data") == 0) {
+            _dataFileName = value.asString();
+            dataSet = true;
+        } else if (name.compare("randomseed") == 0)
+            _randomSeed = value.asInt();
+        else if (name.compare("command") == 0)
+        {
+            if (vstring.compare("train") == 0)
+                _mode = Mode::Training;
+            else if (vstring.compare("predict") == 0)
+                _mode = Mode::Prediction;
+            else if (vstring.compare("validate") == 0)
+                _mode = Mode::Validation;
+            else
+            {
+                printf("*** CDL::Load_JSON: Command unknown:  %s\n", vstring.c_str());
+                return -1;
+            }
+            commandSet = true;
+        }
+        else if (name.compare("trainingparameters") == 0)
+        {
+            for (Json::ValueIterator pitr = value.begin(); pitr != value.end() ; pitr++)
+            {
+                string pname                = pitr.name();
+                std::transform(pname.begin(), pname.end(), pname.begin(), ::tolower);
+                Json::Value pkey            = pitr.key();
+                Json::Value pvalue          = *pitr;
+                if (pname.compare("epochs") == 0) {
+                    _epochs = pvalue.asInt();
+                    epochsSet = true;
+                } else if (pname.compare("alpha") == 0)
+                    _alpha = pvalue.asFloat();
+                else if (pname.compare("alphainterval") == 0)
+                    _alphaInterval = pvalue.asFloat();
+                else if (pname.compare("alphamultiplier") == 0)
+                    _alphaMultiplier = pvalue.asFloat();
+                else if (pname.compare("mu") == 0)
+                    _mu = pvalue.asFloat();
+                else if (pname.compare("lambda") == 0)
+                    _lambda = pvalue.asFloat();
+                else if (pname.compare("checkpointinterval") == 0)
+                    _checkpointInterval = pvalue.asFloat();
+                else if (pname.compare("checkpointname") == 0)
+                    _checkpointFileName = pvalue.asString();
+                else if (pname.compare("optimizer") ==0)
+                {
+                    string pstring = pvalue.isString() ? pvalue.asString() : "";
+                    std::transform(pstring.begin(), pstring.end(), pstring.begin(), ::tolower);
+                    auto it = sOptimizationMap.find(pstring);
+                    if (it != sOptimizationMap.end())
+                        _optimizer = it->second;
+                    else
+                    {
+                        printf("CDL::Load_JSON: Invalid TrainingParameter Optimizer: %s\n", pstring.c_str());
+                        return -1;
+                    }
+                }
+                else if (pname.compare("results") == 0) {
+                    _resultsFileName = pvalue.asString();
+                } else {
+                    name = pitr.name();
+                    printf("CDL::Load_JSON: Invalid TrainingParameter: %s\n", name.c_str());
+                    return -1;
+                }
+            }
+        }
+        else
+        {
+            printf("*** CDL::Load_JSON: Unknown keyword:  %s\n", name.c_str());
+            return -1;
+        }
+    }
+
+    // alphaInterval of zero is specified to mean a constant alpha, so
+    // if they want a constant alpha, then set up the other variables to make it so
+    if (_alphaInterval == 0)
+    {
+        _alphaInterval = 20;
+        _alphaMultiplier = 1;
+    }
+
+    if (!networkSet)
+    {
+        printf("CDL::Load_JSON: Network is required to be set, none found\n");
+        return -1;
+    }
+    if (!commandSet)
+    {
+        printf("CDL::Load_JSON: Command is required, none found\n");
+        return -1;
+    }
+    if (!dataSet)
+    {
+        printf("CDL::Load_JSON: Data source file is required to be set\n");
+        return -1;
+    }
+    if (_mode == Mode::Training && !epochsSet)
+    {
+        printf("CDL::Load_JSON: Mode set to Training, requires number of epochs to be set\n");
+        return -1;
+    }
+
+    printf("CDL::Load_JSON: %s successfully parsed\n", fname.c_str());
+
+    return 0;
+}
+
+

--- a/src/amazon/dsstne/utils/cdl.h
+++ b/src/amazon/dsstne/utils/cdl.h
@@ -1,0 +1,31 @@
+#include "GpuTypes.h"
+#include "NNTypes.h"
+
+
+struct CDL
+{
+    CDL();
+    int Load_JSON(const string& fname);
+
+
+    std::string     _networkFileName;    // NetCDF or JSON Object file name (required)
+    int             _randomSeed;         // Initializes RNG for reproducible runs (default: sets from time of day)
+    Mode            _mode;
+    std::string     _dataFileName;
+
+    // training params
+    int             _epochs; // total epochs
+    int             _batch;  // used by inference as well:  Mini-batch size (default 500, use 0 for entire dataset)
+    float           _alpha;
+    float           _lambda;
+    float           _mu;
+    int             _alphaInterval;      // number of epochs per update to alpha - so this is the number of epochs per DSSTNE call
+    float           _alphaMultiplier;    // amount to scale alpha every alphaInterval number of epochs
+    TrainingMode    _optimizer;
+    std::string     _checkpointFileName;
+    int             _checkpointInterval;
+    bool            _shuffleIndexes;
+    std::string     _resultsFileName;
+};
+
+


### PR DESCRIPTION
adding CDL object, updated encoder to use this json object

*Issue #39 , if available:*
Comand Definition Language - Issue #39

*Description of changes:*
Added support for the CDL.  With this change, encoder will now take as a parameter a CDL file, then use the commands within there to run the network.
I've updated the CDL slightly to reflect new parameters.

We can add other parameters as we go.  This file should make development with encoder to run more smoothly, because it used to require recompiling the main.cpp to switch from train to predict, etc.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
