### PR TITLE
Allow INCLUDE and LIB flags to be overriden before calling make. Remo…

### DIFF
--- a/src/amazon/dsstne/Makefile.inc
+++ b/src/amazon/dsstne/Makefile.inc
@@ -1,7 +1,7 @@
 #
 # For debugging add '-DMEMTRACKING -gdwarf-3' to CPPFLAGS and CFLAGS
 #
-CPP = /lib/cpp
+CPP ?= /lib/cpp
 #CPPFLAGS = -traditional -P -std=c++0x
 CC = mpiCC
 
@@ -18,8 +18,8 @@ else
 endif
 
 NVCC = nvcc
-CU_INCLUDES = -I/usr/local/cuda/include -IB40C -IB40C/KernelCommon -I/usr/local/include -I/usr/lib/openmpi/include -I/usr/include/jsoncpp -I../utils -I../engine -I/usr/include/cppunit
-CU_LIBS = -L/usr/lib/atlas-base -L/usr/local/cuda/lib64 -L. -L/usr/local/lib/
+CU_INCLUDES ?= -I/usr/local/cuda/include -IB40C -IB40C/KernelCommon -I/usr/local/include -I/usr/lib/openmpi/include -I/usr/include/jsoncpp -I../utils -I../engine -I/usr/include/cppunit
+CU_LIBS ?= -L/usr/lib/atlas-base -L/usr/local/cuda/lib64 -L. -L/usr/local/lib/
 CU_LOADLIBS = -lcudnn -lcurand -lcublas -lcudart -lmpi -lmpi_cxx -ljsoncpp -lnetcdf_c++4 -lnetcdf -lblas -ldl -lstdc++  
 
 LOAD = mpiCC

--- a/src/amazon/dsstne/engine/NNTypes.h
+++ b/src/amazon/dsstne/engine/NNTypes.h
@@ -22,7 +22,7 @@
 #include <netcdf>
 #ifndef __NVCC__
 #include <tuple>
-#include <jsoncpp/json/json.h>
+#include <json/json.h>
 #endif
 #include <cmath>
 #include <memory>


### PR DESCRIPTION
…ve jsoncpp directory prefix in include statment in NNTypes.h.

*Issue #, if available:*

*Description of changes:*
1. Allows CU_INCLUDE and CU_LIB flags to be overridden prior to calling make. If these variables are *not* overridden then they *default to the original values*. 
1. Remove jsoncpp directory prefix in `engine/NNTypes.h: #include jsoncpp/json/json.h` as we already include `/usr/lib/jsoncpp`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
