### PR TITLE
adding include dir to gitignore, so checkins are easier again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 /src/amazon/dsstne/bin/
 /src/amazon/dsstne/lib/
+/src/amazon/dsstne/include/
 /src/amazon/dsstne/utils/encoder
 /src/amazon/dsstne/utils/generateNetCDF
 /src/amazon/dsstne/utils/predict


### PR DESCRIPTION
*Description of changes:*
include/ is a directory that is generated on build.  Which means after a build, git thinks it needs to push this directory.  Adding this to the .gitignore, where the other created directories are already enumerated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
