### PR TITLE
Fix breakage due to GetLayer and GetUnitBuffer returning non-const and LoadNeuralNetworkNetCDF not handling missing decay field

### DIFF
--- a/src/amazon/dsstne/engine/NNNetwork.cpp
+++ b/src/amazon/dsstne/engine/NNNetwork.cpp
@@ -3800,8 +3800,9 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             if (decayAtt.isNull())
             {
                 nd._decay = (NNFloat)0.0;
+            } else {
+                decayAtt.getValues(&(nd._decay));
             }
-            decayAtt.getValues(&(nd._decay));            
 
             NcGroupAtt maxout_kAtt              = nc.getAtt("maxout_k");
             if (maxout_kAtt.isNull())

--- a/src/amazon/dsstne/utils/NNRecsGenerator.cpp
+++ b/src/amazon/dsstne/utils/NNRecsGenerator.cpp
@@ -55,7 +55,7 @@ NNRecsGenerator::NNRecsGenerator(unsigned int xBatchSize,
 {
 }
 
-void NNRecsGenerator::generateRecs(const NNNetwork *xNetwork,
+void NNRecsGenerator::generateRecs(NNNetwork *xNetwork,
                                    unsigned int xK,
                                    const FilterConfig *xFilterSet,
                                    const vector<string> &xCustomerIndex,

--- a/src/amazon/dsstne/utils/NNRecsGenerator.h
+++ b/src/amazon/dsstne/utils/NNRecsGenerator.h
@@ -42,7 +42,7 @@ public:
                     const std::string &layer = DEFAULT_LAYER_RECS_GEN_LABEL,
                     const std::string &precision = DEFAULT_SCORE_PRECISION);
 
-    void generateRecs(const NNNetwork *network,
+    void generateRecs(NNNetwork *network,
                       unsigned int topK,
                       const FilterConfig *filters,
                       const std::vector<std::string> &customerIndex,


### PR DESCRIPTION
…twork::GetLayer returning non-const (commit 63a14010fc1350b80e51ff638abf3c5285264f29).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
