### PR TITLE
Set minValue to the new min after bitonic sort to properly filter val…

### DIFF
--- a/src/amazon/dsstne/engine/kernels.cu
+++ b/src/amazon/dsstne/engine/kernels.cu
@@ -3272,6 +3272,12 @@ __shared__ volatile uint32_t sValue[64 * 4];
                 bool flag;
                 BITONICSORT64_64();
 
+                // Set minValue to the new min in the warp register queue
+                // Registers are sorted in descending order k0 > k1 > k2 ... > k_n
+                // Since we sort 2k elements, k^th smallest value is in k_(k/32-1)
+                // in lane warpSize - 1 (if warpSize = 32, then 31)
+                minValue = SHFL(k0, cData._warpSize - 1);
+
                 // Shift members in shared memory to beginning
                 bufferSize         -= 32;
                 if (tgx < bufferSize)
@@ -3400,6 +3406,12 @@ __shared__ volatile uint32_t sValue[96 * 4];
                 v3                  = psValue[tgx + cData._warpSize];
                 bool flag;
                 BITONICSORT128_128();
+
+                // Set minValue to the new min in the warp register queue
+                // Registers are sorted in descending order k0 > k1 > k2 ... > k_n
+                // Since we sort 2k elements, k^th smallest value is in k_(k/32-1)
+                // in lane warpSize - 1 (if warpSize = 32, then 31)
+                minValue = SHFL(k1, cData._warpSize - 1);
 
                 // Shift members in shared memory to beginning
                 bufferSize         -= 64;
@@ -3565,6 +3577,12 @@ __shared__ volatile uint32_t sValue[160 * 4];
                 v7                  = psValue[tgx + 3 * cData._warpSize];
                 bool flag;
                 BITONICSORT256_256();
+
+                // Set minValue to the new min in the warp register queue
+                // Registers are sorted in descending order k0 > k1 > k2 ... > k_n
+                // Since we sort 2k elements, k^th smallest value is in k_(k/32-1)
+                // in lane warpSize - 1 (if warpSize = 32, then 31)
+                minValue = SHFL(k3, cData._warpSize - 1);
 
                 // Shift members in shared memory to beginning
                 bufferSize         -= 128;
@@ -3804,6 +3822,12 @@ __shared__ volatile uint32_t sValue[288 * 4];
                 v15                 = psValue[tgx + 7 * cData._warpSize];
                 bool flag;
                 BITONICSORT512_512();
+
+                // Set minValue to the new min in the warp register queue
+                // Registers are sorted in descending order k0 > k1 > k2 ... > k_n
+                // Since we sort 2k elements, k^th smallest value is in k_(k/32-1)
+                // in lane warpSize - 1 (if warpSize = 32, then 31)
+                minValue = SHFL(k7, cData._warpSize - 1);
 
                 // Shift members in shared memory to beginning
                 bufferSize         -= 256;


### PR DESCRIPTION
*Description of changes:*
After bitonic sort is called (when the shared mem buffer gets full), we should set the minVal equal to the register that contains the smallest value (the largest numbered register since the sorting is in descending order). This has the effect of filtering out values that are smaller than the running k^th element, hence reducing the number of times we call bitonic sort.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
