### PR TITLE
FIX: Latest version f64044d does not compile with docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH=/usr/local/openmpi/bin/:${PATH} \
 
 # Build latest version of DSSTNE from source
 COPY . /opt/amazon/dsstne
-RUN cd /opt/amazon/dsstne/src/amazon/dsstne && \
+RUN cd /opt/amazon/dsstne && \
     make install
 
 # Cleanup

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,4 +54,4 @@ RUN cd /opt/amazon/dsstne && \
 RUN rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Add DSSTNE binaries to PATH
-ENV PATH=/opt/amazon/dsstne/src/amazon/dsstne/bin/:${PATH}
+ENV PATH=/opt/amazon/dsstne/bin/:${PATH}

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ runtime:
 tests:
 	cd tst && make
 
-java: | engine runtime tests
-	cd java && make
+#java: | engine runtime tests
+#	cd java && make
 
 install: all
 	mkdir -p $(PREFIX)
@@ -38,4 +38,4 @@ clean:
 	cd src/amazon/dsstne/utils && make clean
 	cd tst && make clean
 
-.PHONY: engine runtime tests java clean 
+#.PHONY: engine runtime tests java clean 


### PR DESCRIPTION
Latest version  f64044d does not compile because of two main reasons: 
- Dockerfile contains wrong path: /opt/amazon/dsstne/src/amazon/dsstne the correct path is /opt/amazon/dsstne
- Makefile / java does not compile currently. Commented out as this way dsstne compiles and usable in docker without java support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
