### PR TITLE
bugfix for legacy shuffle API

### DIFF
--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -187,10 +187,10 @@ sudo apt-get install libcppunit-dev
 #### CUB Setup
 ```bash
 # Ubuntu/Linux 64-bit
-wget https://github.com/NVlabs/cub/archive/1.5.2.zip
+wget https://github.com/NVlabs/cub/archive/1.8.0.zip
 sudo apt-get install -y unzip
-unzip 1.5.2.zip
-sudo cp -rf cub-1.5.2/cub/ /usr/local/include/
+unzip 1.8.0.zip
+sudo cp -rf cub-1.8.0/cub/ /usr/local/include/
 ```
 
 #### cuDNN

--- a/src/amazon/dsstne/knn/topk.cu
+++ b/src/amazon/dsstne/knn/topk.cu
@@ -138,7 +138,7 @@ __shared__ volatile uint32_t sValue[160 * 4];
 
                 // Set minValue to the new min in the warp queue (registers sorted in descending order)
                 // last register in the last lane (31) holds the smallest value
-                minValue = __shfl(k3, 31);
+                minValue = SHFL(k3, 31);
 
                 // Shift members in shared memory to beginning
                 bufferSize         -= 128;


### PR DESCRIPTION
*Issue #, if available:* #227 

*Description of changes:*
* Replace `__shfl` with `SHFL` to keep CUDA shuffle API compatible
* Update README.md to guide user to download new version CUB library because old CUB library uses legacy CUDA shuffle API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
