### PR TITLE
bugfix for legacy netCDF API

### DIFF
--- a/src/amazon/dsstne/engine/NNLayer.cpp
+++ b/src/amazon/dsstne/engine/NNLayer.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "GpuTypes.h"
+#include "NcExcptionWrap.h"
 #include "NNTypes.h"
 #include "kernels.h"
 #define __STDC_FORMAT_MACROS
@@ -3007,21 +3008,21 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt nameAtt                  = nc.getAtt(lstring + "name");
             if (nameAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No name supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No name supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             nameAtt.getValues(ld._name);
 
             NcGroupAtt kindAtt                  = nc.getAtt(lstring + "kind");
             if (kindAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kind supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kind supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kindAtt.getValues(&ld._kind);
 
             NcGroupAtt typeAtt                  = nc.getAtt(lstring + "type");
             if (typeAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No type supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No type supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             typeAtt.getValues(&ld._type);
             
@@ -3029,7 +3030,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             if (poolingFunctionAtt.isNull())
             {
                 if (ld._type == NNLayer::Type::Pooling)
-                    throw NcException("NcException", "NNLayer::NNLayer: No pooling function supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No pooling function supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 ld._poolingFunction             = None;
             }
             else
@@ -3038,84 +3039,84 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt dataSetAtt               = nc.getAtt(lstring + "dataSet");
             if (dataSetAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No dataSet supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No dataSet supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             dataSetAtt.getValues(ld._dataSet);
 
             NcGroupAtt NxAtt                    = nc.getAtt(lstring + "Nx");
             if (NxAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No Nx supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No Nx supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             NxAtt.getValues(&ld._Nx);
 
             NcGroupAtt NyAtt                    = nc.getAtt(lstring + "Ny");
             if (NyAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No Ny supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No Ny supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             NyAtt.getValues(&ld._Ny);
 
             NcGroupAtt NzAtt                    = nc.getAtt(lstring + "Nz");
             if (NzAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No Nz supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No Nz supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             NzAtt.getValues(&ld._Nz);
 
             NcGroupAtt NwAtt                    = nc.getAtt(lstring + "Nw");
             if (NwAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No Nw supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No Nw supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             NwAtt.getValues(&ld._Nw);
 
             NcGroupAtt dimensionsAtt            = nc.getAtt(lstring + "dimensions");
             if (dimensionsAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No dimensions supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No dimensions supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             dimensionsAtt.getValues(&ld._dimensions);
 
             NcGroupAtt kernelXAtt               = nc.getAtt(lstring + "kernelX");
             if (kernelXAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelX supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelX supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelXAtt.getValues(&ld._kernelX);
 
             NcGroupAtt kernelYAtt               = nc.getAtt(lstring + "kernelY");
             if (kernelYAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelY supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelY supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelYAtt.getValues(&ld._kernelY);
 
             NcGroupAtt kernelZAtt               = nc.getAtt(lstring + "kernelZ");
             if (kernelZAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelZ supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelZ supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelZAtt.getValues(&ld._kernelZ);
 
             NcGroupAtt kernelStrideXAtt         = nc.getAtt(lstring + "kernelStrideX");
             if (kernelStrideXAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelStrideX supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelStrideX supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelStrideXAtt.getValues(&ld._kernelStrideX);
 
             NcGroupAtt kernelStrideYAtt         = nc.getAtt(lstring + "kernelStrideY");
             if (kernelStrideYAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelStrideY supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelStrideY supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelStrideYAtt.getValues(&ld._kernelStrideY);
 
             NcGroupAtt kernelStrideZAtt         = nc.getAtt(lstring + "kernelStrideZ");
             if (kernelStrideZAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelStrideZ supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelStrideZ supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelStrideZAtt.getValues(&ld._kernelStrideZ);
 
@@ -3123,35 +3124,35 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt kernelPaddingXAtt        = nc.getAtt(lstring + "kernelPaddingX");
             if (kernelPaddingXAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelPaddingX supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelPaddingX supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelPaddingXAtt.getValues(&ld._kernelPaddingX);
 
             NcGroupAtt kernelPaddingYAtt        = nc.getAtt(lstring + "kernelPaddingY");
             if (kernelPaddingYAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelPaddingY supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelPaddingY supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelPaddingYAtt.getValues(&ld._kernelPaddingY);
 
             NcGroupAtt kernelPaddingZAtt        = nc.getAtt(lstring + "kernelPaddingZ");
             if (kernelPaddingZAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelPaddingZ supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelPaddingZ supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelPaddingZAtt.getValues(&ld._kernelPaddingZ);          
 
             NcGroupAtt kernelDimensionsAtt      = nc.getAtt(lstring + "kernelDimensions");
             if (kernelDimensionsAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No kernelDimensions supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No kernelDimensions supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kernelDimensionsAtt.getValues(&ld._kernelDimensions);
             
             NcGroupAtt weightInitAtt            = nc.getAtt(lstring + "weightInit");
             if (weightInitAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No weightInit supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No weightInit supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 ld._weightInit                  = Xavier;
             }
             else
@@ -3160,7 +3161,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt weightInitScaleAtt       = nc.getAtt(lstring + "weightInitScale");
             if (weightInitScaleAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No weightInitScale supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No weightInitScale supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 ld._weightInitScale             = (NNFloat)1.0;
             }
             else
@@ -3169,7 +3170,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt biasInitAtt              = nc.getAtt(lstring + "biasInit");
             if (biasInitAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No biasInit supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No biasInit supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 ld._biasInit                    = (NNFloat)0.0;
             }
             else
@@ -3178,7 +3179,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt weightNormAtt            = nc.getAtt(lstring + "weightNorm");
             if (weightNormAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No weightNorm supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No weightNorm supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 ld._weightNorm                  = (NNFloat)0.0;
             }
             else
@@ -3187,7 +3188,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt deltaNormAtt             = nc.getAtt(lstring + "deltaNorm");
             if (deltaNormAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No deltaNorm supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No deltaNorm supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 ld._deltaNorm                   = (NNFloat)0.0;
             }
             else
@@ -3196,7 +3197,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt pDropoutAtt              = nc.getAtt(lstring + "pDropout");
             if (pDropoutAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No pDropout supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No pDropout supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             else
                 pDropoutAtt.getValues(&ld._pDropout);
@@ -3204,7 +3205,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt activationAtt            = nc.getAtt(lstring + "activation");
             if (activationAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No activation supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No activation supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             activationAtt.getValues(&ld._activation);
 
@@ -3212,7 +3213,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt RELUSlopeAtt             = nc.getAtt(lstring + "RELUSlope");
             if (RELUSlopeAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No RELUSlope supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No RELUSlope supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             RELUSlopeAtt.getValues(&(ld._RELUSlope));
 
@@ -3221,7 +3222,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt ELUAlphaAtt              = nc.getAtt(lstring + "ELUAlpha");
             if (ELUAlphaAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No ELUAlpha supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No ELUAlpha supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             ELUAlphaAtt.getValues(&(ld._ELUAlpha));
             
@@ -3229,14 +3230,14 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt SELULambdaAtt            = nc.getAtt(lstring + "SELULambda");
             if (SELULambdaAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No SELULambda supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No SELULambda supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             SELULambdaAtt.getValues(&(ld._SELULambda)); 
             
             NcGroupAtt sparsenessPenalty_pAtt   = nc.getAtt("sparsenessPenalty_p");   
             if (sparsenessPenalty_pAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No sparsenessPenalty_p supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No sparsenessPenalty_p supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             else
             {
@@ -3246,7 +3247,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt sparsenessPenalty_betaAtt= nc.getAtt("sparsenessPenalty_beta");
             if (sparsenessPenalty_betaAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No sparsenessPenalty_beta supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No sparsenessPenalty_beta supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 ld._sparsenessPenalty_p = (NNFloat)0.0;
             }
             else
@@ -3257,7 +3258,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt attributesAtt            = nc.getAtt(lstring + "attributes");
             if (attributesAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No attributes supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No attributes supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             attributesAtt.getValues(&ld._attributes);
 
@@ -3286,7 +3287,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt sourcesAtt               = nc.getAtt(lstring + "sources");
             if (sourcesAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No sources supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No sources supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             sourcesAtt.getValues(&sources);
 
@@ -3296,7 +3297,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
                 NcGroupAtt sourceAtt            = nc.getAtt(lstring + "source" + nstring);
                 if (sourcesAtt.isNull())
                 {
-                    throw NcException("NcException", "NNLayer::NNLayer: No source attributes supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No source attributes supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 string source;
                 sourceAtt.getValues(source);
@@ -3308,7 +3309,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
             NcGroupAtt skipsAtt                 = nc.getAtt(lstring + "skips");
             if (skipsAtt.isNull())
             {
-                throw NcException("NcException", "NNLayer::NNLayer: No skips supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No skips supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             skipsAtt.getValues(&skips);
 
@@ -3318,7 +3319,7 @@ bool LoadNNLayerDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint32
                 NcGroupAtt skipAtt              = nc.getAtt(lstring + "skip" + nstring);
                 if (skipAtt.isNull())
                 {
-                    throw NcException("NcException", "NNLayer::NNLayer: No skip attributes supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNLayer::NNLayer: No skip attributes supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 string skip;
                 skipAtt.getValues(skip);

--- a/src/amazon/dsstne/engine/NNNetwork.cpp
+++ b/src/amazon/dsstne/engine/NNNetwork.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "GpuTypes.h"
+#include "NcExcptionWrap.h"
 #include "NNTypes.h"
 #include "kernels.h"
 #include "Utils.h"
@@ -3786,28 +3787,28 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt versionAtt               = nc.getAtt("version");
             if (versionAtt.isNull())
             {
-                throw NcException("NcException", "NNNetwork::NNetwork: No version supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNNetwork::NNetwork: No version supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             versionAtt.getValues(&version);
 
             NcGroupAtt nameAtt                  = nc.getAtt("name");
             if (nameAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No name supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No name supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             nameAtt.getValues(nd._name);
 
             NcGroupAtt kindAtt                  = nc.getAtt("kind");
             if (nameAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No kind supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No kind supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             kindAtt.getValues(&(nd._kind));
 
             NcGroupAtt errorFunctionAtt         = nc.getAtt("errorFunction");
             if (errorFunctionAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No error function supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No error function supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             errorFunctionAtt.getValues(&(nd._errorFunction));
 
@@ -3822,42 +3823,42 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt maxout_kAtt              = nc.getAtt("maxout_k");
             if (maxout_kAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No maxout_k supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No maxout_k supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             maxout_kAtt.getValues(&(nd._maxout_k));
 
             NcGroupAtt LRN_kAtt                 = nc.getAtt("LRN_k");
             if (LRN_kAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No LRN_k supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No LRN_k supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             LRN_kAtt.getValues(&(nd._LRN_k));
 
             NcGroupAtt LRN_nAtt                 = nc.getAtt("LRN_n");
             if (LRN_nAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No LRN_n supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No LRN_n supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             LRN_nAtt.getValues(&(nd._LRN_n));
 
             NcGroupAtt LRN_alphaAtt             = nc.getAtt("LRN_alpha");
             if (LRN_alphaAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No LRN_alpha supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No LRN_alpha supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             LRN_alphaAtt.getValues(&(nd._LRN_alpha));
 
             NcGroupAtt LRN_betaAtt              = nc.getAtt("LRN_beta");
             if (LRN_betaAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No LRN_beta supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No LRN_beta supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             LRN_betaAtt.getValues(&(nd._LRN_beta));
 
             NcGroupAtt bSparsenessPenaltyAtt    = nc.getAtt("bSparsenessPenalty");
             if (bSparsenessPenaltyAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No bSparsenessPenalty supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No bSparsenessPenalty supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             uint32_t bSparsenessPenalty;
             bSparsenessPenaltyAtt.getValues(&bSparsenessPenalty);
@@ -3866,21 +3867,21 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt sparsenessPenalty_pAtt   = nc.getAtt("sparsenessPenalty_p");
             if (sparsenessPenalty_pAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No sparsenessPenalty_p supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No sparsenessPenalty_p supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             sparsenessPenalty_pAtt.getValues(&(nd._sparsenessPenalty_p));
 
             NcGroupAtt sparsenessPenalty_betaAtt= nc.getAtt("sparsenessPenalty_beta");
             if (sparsenessPenalty_betaAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No sparsenessPenalty_beta supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No sparsenessPenalty_beta supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             sparsenessPenalty_betaAtt.getValues(&(nd._sparsenessPenalty_beta));
 
             NcGroupAtt bDenoisingAtt            = nc.getAtt("bDenoising");
             if (bDenoisingAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No bDenoising supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No bDenoising supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             uint32_t bDenoising;
             bDenoisingAtt.getValues(&bDenoising);
@@ -3889,7 +3890,7 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt denoising_pAtt           = nc.getAtt("denoising_p");
             if (denoising_pAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No denoising_p supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No denoising_p supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             denoising_pAtt.getValues(&(nd._denoising_p));
 
@@ -3898,14 +3899,14 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt deltaBoost_oneAtt        = nc.getAtt("deltaBoost_one");
             if (deltaBoost_oneAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No deltaBoost_one supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No deltaBoost_one supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             deltaBoost_oneAtt.getValues(&(nd._deltaBoost_one));
 
             NcGroupAtt deltaBoost_zeroAtt       = nc.getAtt("deltaBoost_zero");
             if (deltaBoost_zeroAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No deltaBoost_zero supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No deltaBoost_zero supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             deltaBoost_zeroAtt.getValues(&(nd._deltaBoost_zero));
 
@@ -3913,35 +3914,35 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt SMCE_oneScaleAtt         = nc.getAtt("SMCE_oneScale");
             if (SMCE_oneScaleAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No SMCE_oneScale supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No SMCE_oneScale supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             SMCE_oneScaleAtt.getValues(&(nd._SMCE_oneScale));
 
             NcGroupAtt SMCE_zeroScaleAtt        = nc.getAtt("SMCE_zeroScale");
             if (SMCE_zeroScaleAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No SMCE_zeroScale supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No SMCE_zeroScale supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             SMCE_zeroScaleAtt.getValues(&(nd._SMCE_zeroScale));
 
             NcGroupAtt SMCE_oneTargetAtt        = nc.getAtt("SMCE_oneTarget");
             if (SMCE_oneTargetAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No SMCE_oneTarget supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No SMCE_oneTarget supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             SMCE_oneTargetAtt.getValues(&(nd._SMCE_oneTarget));
 
             NcGroupAtt SMCE_zeroTargetAtt       = nc.getAtt("SMCE_zeroTarget");
             if (SMCE_zeroTargetAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No SMCE_zeroTarget supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No SMCE_zeroTarget supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             SMCE_zeroTargetAtt.getValues(&(nd._SMCE_zeroTarget));
 
             NcGroupAtt checkpoint_nameAtt       = nc.getAtt("checkpoint_name");
             if (checkpoint_nameAtt.isNull())
             {
-                //throw NcException("NcException", "NNetwork::NNetwork: No checkpoint_name supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                //throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No checkpoint_name supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 // Use default value from constructor
             }
             else
@@ -3950,7 +3951,7 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt checkpoint_intervalAtt   = nc.getAtt("checkpoint_interval");
             if (checkpoint_intervalAtt.isNull())
             {
-                //throw NcException("NcException", "NNetwork::NNetwork: No checkpoint_interval supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                //throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No checkpoint_interval supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 // Use default value from constructor
             }
             else
@@ -3959,7 +3960,7 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt checkpoint_epochsAtt     = nc.getAtt("checkpoint_epochs");
             if (checkpoint_epochsAtt.isNull())
             {
-                //throw NcException("NcException", "NNetwork::NNetwork: No checkpoint_epochs supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                //throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No checkpoint_epochs supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 // Use default value from constructor
             }
             else
@@ -3969,7 +3970,7 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt shuffleIndicesAtt        = nc.getAtt("ShuffleIndices");
             if (shuffleIndicesAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No shuffleIndices supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No shuffleIndices supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             uint32_t bShuffleIndices;
             shuffleIndicesAtt.getValues(&bShuffleIndices);
@@ -3979,7 +3980,7 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt layersAtt                = nc.getAtt("layers");
             if (layersAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No layers supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No layers supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             layersAtt.getValues(&layers);
 
@@ -3989,7 +3990,7 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
                 NNLayerDescriptor ld;
                 if (!LoadNNLayerDescriptorNetCDF(fname, nc, i, ld))
                 {
-                    throw NcException("NcException", "NNetwork::NNetwork: Error reading layer data in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: Error reading layer data in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 nd._vLayerDescriptor.push_back(ld);
             }
@@ -3998,7 +3999,7 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
             NcGroupAtt weightsAtt               = nc.getAtt("weights");
             if (weightsAtt.isNull())
             {
-                throw NcException("NcException", "NNetwork::NNetwork: No weights supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: No weights supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             weightsAtt.getValues(&weights);
 
@@ -4008,7 +4009,7 @@ NNNetwork* LoadNeuralNetworkNetCDF(const string& fname, const uint32_t batch)
                 NNWeightDescriptor wd;
                 if (!LoadNNWeightDescriptorNetCDF(fname, nc, i, wd))
                 {
-                    throw NcException("NcException", "NNetwork::NNetwork: Error reading weight data in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNetwork::NNetwork: Error reading weight data in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 nd._vWeightDescriptor.push_back(wd);
             }

--- a/src/amazon/dsstne/engine/NNTypes.cpp
+++ b/src/amazon/dsstne/engine/NNTypes.cpp
@@ -14,6 +14,7 @@
 #include <sstream>
 
 #include "GpuTypes.h"
+#include "NcExcptionWrap.h"
 #include "NNTypes.h"
 #include "kernels.h"
 
@@ -1097,7 +1098,7 @@ _pbSparseData()
             NcGroupAtt nameAtt                  = nfc.getAtt(vname);
             if (nameAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: No dataset name supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No dataset name supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             nameAtt.getValues(_name);
             cout << "NNDataSet<T>::NNDataSet: Name of data set: " << _name << endl;
@@ -1107,7 +1108,7 @@ _pbSparseData()
             NcGroupAtt dataTypeAtt              = nfc.getAtt(vname);
             if (dataTypeAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: No datatype supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No datatype supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             int dataType;
             dataTypeAtt.getValues(&dataType);
@@ -1117,7 +1118,7 @@ _pbSparseData()
             NcGroupAtt attributesAtt            = nfc.getAtt(vname);
             if (attributesAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: No attributes supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No attributes supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             attributesAtt.getValues(&_attributes);
             if (_attributes != 0)
@@ -1137,14 +1138,14 @@ _pbSparseData()
             NcDim examplesDim                   = nfc.getDim(vname);
             if (examplesDim.isNull())
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: No examples count supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No examples count supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             _examples                           = examplesDim.getSize();
 
             // Check for nonzero examples count
             if (_examples == 0)
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: Zero-valued Examples count in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: Zero-valued Examples count in NetCDF input file " + fname, __FILE__, __LINE__);
             }
 
             // Grab unique examples count if present
@@ -1163,21 +1164,21 @@ _pbSparseData()
             NcGroupAtt dimensionsAtt            = nfc.getAtt(vname);
             if (dimensionsAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: No dimension count supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No dimension count supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             dimensionsAtt.getValues(&_dimensions);
 
             // Check for valid dimensions count
             if ((_dimensions < 1) || (_dimensions > 3))
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: Invalid dimension count (" + to_string(_dimensions) + ") supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: Invalid dimension count (" + to_string(_dimensions) + ") supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
 
             vname                               = "width" + nstring;
             NcGroupAtt widthAtt                 = nfc.getAtt(vname);
             if (widthAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: No datapoint width supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No datapoint width supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             widthAtt.getValues(&_width);
 
@@ -1187,7 +1188,7 @@ _pbSparseData()
                 NcGroupAtt heightAtt            = nfc.getAtt(vname);
                 if (heightAtt.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: No datapoint height supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No datapoint height supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 heightAtt.getValues(&_height);
             }
@@ -1200,7 +1201,7 @@ _pbSparseData()
                 NcGroupAtt lengthAtt            = nfc.getAtt(vname);
                 if (lengthAtt.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: No datapoint length supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No datapoint length supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 lengthAtt.getValues(&_length);
             }
@@ -1211,7 +1212,7 @@ _pbSparseData()
             // Make sure all dimensions are at least 1
             if ((_width == 0) || (_height == 0) || (_length == 0))
             {
-                throw NcException("NcException", "NNDataSet::NNDataSet: Invalid dataset dimensions in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: Invalid dataset dimensions in NetCDF input file " + fname, __FILE__, __LINE__);
             }
 
             // Read sparse data (type is irrelevant here)
@@ -1223,14 +1224,14 @@ _pbSparseData()
                 NcDim sparseDataDim             = nfc.getDim(vname);
                 if (sparseDataDim.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: No sparse data dimensions supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No sparse data dimensions supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 _sparseDataSize                 = sparseDataDim.getSize();
 
                 // Check for at least one datapoint
                 if (_sparseDataSize == 0)
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: Sparse data set with no actual data in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: Sparse data set with no actual data in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
 
                 _vSparseIndex.resize(_sparseDataSize);
@@ -1239,19 +1240,19 @@ _pbSparseData()
                 NcVar sparseStartVar            = nfc.getVar(vname);
                 if (sparseStartVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: No sparse offset start supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No sparse offset start supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 vname                           = "sparseEnd" + nstring;
                 NcVar sparseEndVar              = nfc.getVar(vname);
                 if (sparseEndVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: No sparse data end supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No sparse data end supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 vname                           = "sparseIndex" + nstring;
                 NcVar sparseIndexVar            = nfc.getVar(vname);
                 if (sparseIndexVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: No sparse data indices supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No sparse data indices supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
 
                 // Read data into CPU memory (account for old datasets using 32-bit indices)
@@ -1283,7 +1284,7 @@ _pbSparseData()
                     NcVar sparseDataVar         = nfc.getVar(vname);
                     if (sparseDataVar.isNull())
                     {
-                        throw NcException("NcException", "NNDataSet::NNDataSet: No sparse data located in NetCDF input file " + fname, __FILE__, __LINE__);
+                        throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No sparse data located in NetCDF input file " + fname, __FILE__, __LINE__);
                     }
                     _vSparseData.resize(sparseDataDim.getSize());
                     sparseDataVar.getVar(_vSparseData.data());
@@ -1297,7 +1298,7 @@ _pbSparseData()
                 NcDim dataDim                   = nfc.getDim(vname);
                 if (dataDim.isNull())
                 {
-                        throw NcException("NcException", "NNDataSet::NNDataSet: No data dimensions located in NetCDF input file " + fname, __FILE__, __LINE__);
+                        throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No data dimensions located in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 vname                           = "data" + nstring;
                 NcVar dataVar                   = nfc.getVar(vname);
@@ -1328,7 +1329,7 @@ _pbSparseData()
                 NcVar DataWeightVar         = nfc.getVar(vname);
                 if (DataWeightVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: No data weights located in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No data weights located in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 _vDataWeight.resize(_examples);
                 DataWeightVar.getVar(_vDataWeight.data());
@@ -1341,7 +1342,7 @@ _pbSparseData()
                 NcVar indexVar              = nfc.getVar(vname);
                 if (indexVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: No indexed data located in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: No indexed data located in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                _vIndex.resize(_examples);
                indexVar.getVar(_vIndex.data());
@@ -2177,12 +2178,12 @@ template<typename T> bool NNDataSet<T>::SaveNetCDF(const string& fname)
             NcGroupAtt datasetsAtt          = nfc.putAtt("datasets", ncUint, 1);
             if (datasetsAtt.isNull())
             {
-                throw NcException("NcException", "SaveNetCDF: Unable to write datasets attribute to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "SaveNetCDF: Unable to write datasets attribute to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
             bool bResult                    = WriteNetCDF(nfc, fname, 0);
             if (!bResult)
-                throw NcException("NcException", "SaveNetCDF: Unable to write dataset to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "SaveNetCDF: Unable to write dataset to NetCDF file " + fname, __FILE__, __LINE__);
         }
         catch (NcException& e)
         {
@@ -2225,14 +2226,14 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
             NcGroupAtt nameAtt              = nfc.putAtt(vname, _name);
             if (nameAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset name to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset name to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
             vname                           = "attributes" + nstring;
             NcGroupAtt attributesAtt        = nfc.putAtt(vname, ncUint, _attributes);
             if (attributesAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset attributes to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset attributes to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
             // Stubbed to numeric for now, will eventually be numeric, image, or audio descriptor
@@ -2240,28 +2241,28 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
             NcGroupAtt kindAtt              = nfc.putAtt(vname, ncUint, 0);
             if (kindAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset kind to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset kind to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
             vname                           = "datatype" + nstring;
             NcGroupAtt datatypeAtt          = nfc.putAtt(vname, ncUint, _dataType);
             if (datatypeAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset type to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset type to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
             vname                           = "dimensions" + nstring;
             NcGroupAtt dimensionsAtt        = nfc.putAtt(vname, ncUint, _dimensions);
             if (dimensionsAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset dimensions to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset dimensions to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
             vname                           = "width" + nstring;
             NcGroupAtt widthAtt             = nfc.putAtt(vname, ncUint, _width);
             if (widthAtt.isNull())
             {
-                throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset width to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset width to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
             if (_dimensions > 1)
@@ -2270,7 +2271,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                 NcGroupAtt heightAtt        = nfc.putAtt(vname, ncUint, _height);
                 if (heightAtt.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset height to NetCDF file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset height to NetCDF file " + fname, __FILE__, __LINE__);
                 }
 
                 if (_dimensions > 2)
@@ -2279,7 +2280,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                     NcGroupAtt lengthAtt    = nfc.putAtt(vname, ncUint, _length);
                     if (lengthAtt.isNull())
                     {
-                        throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset length to NetCDF file " + fname, __FILE__, __LINE__);
+                        throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset length to NetCDF file " + fname, __FILE__, __LINE__);
                     }
                 }
             }
@@ -2288,14 +2289,14 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
             NcDim uniqueExamplesDim         = nfc.addDim(vname, (size_t)_uniqueExamples);
             if (uniqueExamplesDim.isNull())
             {
-                throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset unique example count to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset unique example count to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
             vname                           = "examplesDim" + nstring;
             NcDim examplesDim               = nfc.addDim(vname, (size_t)_examples);
             if (examplesDim.isNull())
             {
-                throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset example count to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset example count to NetCDF file " + fname, __FILE__, __LINE__);
             }
 
 
@@ -2305,14 +2306,14 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                 NcDim sparseDataDim         = nfc.addDim(vname, _vSparseIndex.size());
                 if (sparseDataDim.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse datapoint count to NetCDF file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse datapoint count to NetCDF file " + fname, __FILE__, __LINE__);
                 }
 
                 vname                       = "sparseStart" + nstring;
                 NcVar sparseStartVar        = nfc.addVar(vname, "uint", uniqueExamplesDim.getName());
                 if (sparseStartVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse start variable to NetCDF file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse start variable to NetCDF file " + fname, __FILE__, __LINE__);
                 }
                 sparseStartVar.putVar(_vSparseStart.data());
 
@@ -2320,7 +2321,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                 NcVar sparseEndVar          = nfc.addVar(vname, "uint", uniqueExamplesDim.getName());
                 if (sparseEndVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse end variable to NetCDF file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse end variable to NetCDF file " + fname, __FILE__, __LINE__);
                 }
                 sparseEndVar.putVar(_vSparseEnd.data());
 
@@ -2328,7 +2329,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                 NcVar sparseIndexVar        = nfc.addVar(vname, "uint64", sparseDataDim.getName());
                 if (sparseIndexVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse index variable to NetCDF file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse index variable to NetCDF file " + fname, __FILE__, __LINE__);
                 }
                 sparseIndexVar.putVar(_vSparseIndex.data());
 
@@ -2340,7 +2341,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                     NcVar sparseDataVar         = nfc.addVar(vname, sparseType.getName(), sparseDataDim.getName());
                     if (sparseDataVar.isNull())
                     {
-                        throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse data variable to NetCDF file " + fname, __FILE__, __LINE__);
+                        throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to write dataset sparse data variable to NetCDF file " + fname, __FILE__, __LINE__);
                     }
                     sparseDataVar.putVar(_vSparseData.data());
                 }
@@ -2357,7 +2358,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                 NcVar DataWeightVar         = nfc.addVar(vname, "float", uniqueExamplesDim.getName());
                 if (DataWeightVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::NNDataSet: Failed to write data weights to NetCDF file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::NNDataSet: Failed to write data weights to NetCDF file " + fname, __FILE__, __LINE__);
                 }
                 DataWeightVar.putVar(_vDataWeight.data());
             }
@@ -2369,7 +2370,7 @@ template<typename T> bool NNDataSet<T>::WriteNetCDF(NcFile& nfc, const string& f
                 NcVar indexVar              = nfc.addVar(vname, "uint32", examplesDim.getName());
                 if (indexVar.isNull())
                 {
-                    throw NcException("NcException", "NNDataSet::WriteNetCDF: Failed to create dataset index variable to NetCDF file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "NNDataSet::WriteNetCDF: Failed to create dataset index variable to NetCDF file " + fname, __FILE__, __LINE__);
                 }
                 indexVar.putVar(_vIndex.data());
             }
@@ -2412,13 +2413,13 @@ bool SaveNetCDF(const string& fname, vector<NNDataSetBase*> vDataSet)
             NcGroupAtt datasetsAtt          = nfc.putAtt("datasets", ncUint, (unsigned int)vDataSet.size());
             if (datasetsAtt.isNull())
             {
-                throw NcException("NcException", "SaveNetCDF: Unable to write datasets attribute to NetCDF file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "SaveNetCDF: Unable to write datasets attribute to NetCDF file " + fname, __FILE__, __LINE__);
             }
             for (uint32_t i = 0; i < vDataSet.size(); i++)
             {
                 bool bResult                = vDataSet[i]->WriteNetCDF(nfc, fname, i);
                 if (!bResult)
-                    throw NcException("NcException", "SaveNetCDF: Unable to write dataset to NetCDF file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "SaveNetCDF: Unable to write dataset to NetCDF file " + fname, __FILE__, __LINE__);
             }
         }
         catch (NcException& e)
@@ -2470,7 +2471,7 @@ vector<NNDataSetBase*> LoadNetCDF(const string& fname)
             NcGroupAtt dataSetsAtt              = rnc.getAtt("datasets");
             if (dataSetsAtt.isNull())
             {
-                throw NcException("NcException", "LoadNetCDF: No datasets count supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "LoadNetCDF: No datasets count supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             uint32_t datasets;
             dataSetsAtt.getValues(&datasets);
@@ -2482,7 +2483,7 @@ vector<NNDataSetBase*> LoadNetCDF(const string& fname)
                 NcGroupAtt dataTypeAtt          = rnc.getAtt(vname);
                 if (dataTypeAtt.isNull())
                 {
-                      throw NcException("NcException", "LoadNetCDF: No " + vname + " attribute located in NetCDF input file " + fname, __FILE__, __LINE__);
+                      throw NC_EXCEPTION("NcException", "LoadNetCDF: No " + vname + " attribute located in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 uint32_t dataType;
                 dataTypeAtt.getValues(&dataType);

--- a/src/amazon/dsstne/engine/NNWeight.cpp
+++ b/src/amazon/dsstne/engine/NNWeight.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "GpuTypes.h"
+#include "NcExcptionWrap.h"
 #include "NNTypes.h"
 #include "kernels.h"
 #define __STDC_FORMAT_MACROS
@@ -97,21 +98,21 @@ bool LoadNNWeightDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint3
             NcGroupAtt inputLayerAtt            = nc.getAtt(wstring + "inputLayer");
             if (inputLayerAtt.isNull())
             {
-                throw NcException("NcException", "No input layer supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "No input layer supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             inputLayerAtt.getValues(wd._inputLayer);  
 
             NcGroupAtt outputLayerAtt           = nc.getAtt(wstring + "outputLayer");
             if (outputLayerAtt.isNull())
             {
-                throw NcException("NcException", "No output layer supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "No output layer supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             outputLayerAtt.getValues(wd._outputLayer);
 
             NcGroupAtt normAtt                  = nc.getAtt(wstring + "norm");
             if (normAtt.isNull())
             {
-                //throw NcException("NcException", "No norm supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                //throw NC_EXCEPTION("NcException", "No norm supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 wd._norm                        = (NNFloat)0.0;
             }
             else
@@ -120,7 +121,7 @@ bool LoadNNWeightDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint3
             NcGroupAtt bSharedAtt               = nc.getAtt(wstring + "bShared");
             if (bSharedAtt.isNull())
             {
-                throw NcException("NcException", "No bShared supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "No bShared supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             uint32_t bShared;
             bSharedAtt.getValues(&bShared);
@@ -132,19 +133,19 @@ bool LoadNNWeightDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint3
                 NcGroupAtt sourceInputLayerAtt  = nc.getAtt(wstring + "sourceInputLayer");
                 if (sourceInputLayerAtt.isNull())
                 {
-                    throw NcException("NcException", "No sourceInputLayer for shared weights supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "No sourceInputLayer for shared weights supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 sourceInputLayerAtt.getValues(wd._sourceInputLayer);
                 NcGroupAtt sourceOutputLayerAtt = nc.getAtt(wstring + "sourceOutputLayer");
                 if (sourceInputLayerAtt.isNull())
                 {
-                    throw NcException("NcException", "No sourceOutputLayer for shared weights supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "No sourceOutputLayer for shared weights supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 sourceOutputLayerAtt.getValues(wd._sourceOutputLayer);
                 NcGroupAtt bTransposedAtt       = nc.getAtt(wstring + "bTransposed");
                 if (bTransposedAtt.isNull())
                 {
-                    throw NcException("NcException", "No bTransposed for shared weights supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                    throw NC_EXCEPTION("NcException", "No bTransposed for shared weights supplied in NetCDF input file " + fname, __FILE__, __LINE__);
                 }
                 uint32_t bTransposed;
                 bTransposedAtt.getValues(&bTransposed);
@@ -166,35 +167,35 @@ bool LoadNNWeightDescriptorNetCDF(const string& fname, netCDF::NcFile& nc, uint3
             NcGroupAtt widthAtt                 = nc.getAtt(wstring + "width");
             if (widthAtt.isNull())
             {
-                throw NcException("NcException", "No weight width supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "No weight width supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             widthAtt.getValues(&wd._width);
 
             NcGroupAtt heightAtt                = nc.getAtt(wstring + "height");
             if (heightAtt.isNull())
             {
-                throw NcException("NcException", "No weight height supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "No weight height supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             heightAtt.getValues(&wd._height);
 
             NcGroupAtt lengthAtt                = nc.getAtt(wstring + "length");
             if (lengthAtt.isNull())
             {
-                throw NcException("NcException", "No weight length supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "No weight length supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             lengthAtt.getValues(&wd._length);
             
             NcGroupAtt depthAtt                 = nc.getAtt(wstring + "depth");
             if (depthAtt.isNull())
             {
-                throw NcException("NcException", "No weight depth supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "No weight depth supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             depthAtt.getValues(&wd._depth);
             
             NcGroupAtt breadthAtt               = nc.getAtt(wstring + "breadth");
             if (breadthAtt.isNull())
             {
-                throw NcException("NcException", "No weight breadth supplied in NetCDF input file " + fname, __FILE__, __LINE__);
+                throw NC_EXCEPTION("NcException", "No weight breadth supplied in NetCDF input file " + fname, __FILE__, __LINE__);
             }
             breadthAtt.getValues(&wd._breadth);                        
 

--- a/src/amazon/dsstne/engine/NcExcptionWrap.h
+++ b/src/amazon/dsstne/engine/NcExcptionWrap.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <ncException.h>
+#include <string>
+#define NC_EXCEPTION(errorStr, msg, filename, line) NcException(std::string(msg).c_str(), filename, line)


### PR DESCRIPTION
*Issue #, if available:* #226 

*Description of changes:*
Add `NC_EXCEPTION` macro to replace old `NcException` API to let DSSTNE be compatible with newer netCDF library (v4.3)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
