### PR TITLE
Updating CUB version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ RUN apt-get install -y libnetcdf-c++4-dev
 
 # Installing CUBG
 RUN cd /tmp && \
-    wget https://github.com/NVlabs/cub/archive/1.5.2.zip && \
-    unzip 1.5.2.zip && \
-    cp -rf cub-1.5.2/cub/ /usr/local/include/ && \
+    wget https://github.com/NVlabs/cub/archive/1.8.0.zip && \
+    unzip 1.8.0.zip && \
+    cp -rf cub-1.8.0/cub/ /usr/local/include/ && \
     rm -rf /tmp/*
 
 # Ensure OpenMPI is available on path


### PR DESCRIPTION
*Issue #, if available:* #227 

*Description of changes:*
    Update Dockerfile to download new version CUB library because old CUB library uses legacy  CUDA shuffle API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
